### PR TITLE
clearml-agent: allow setting  runtimeClassName in the helm chart

### DIFF
--- a/charts/clearml-agent/Chart.yaml
+++ b/charts/clearml-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml-agent
 description: MLOps platform Task running agent
 type: application
-version: "5.3.2"
+version: "5.3.3"
 appVersion: "1.24"
 kubeVersion: ">= 1.21.0-0 < 1.33.0-0"
 home: https://clear.ml
@@ -20,5 +20,7 @@ keywords:
   - "task agent"
 annotations:
   artifacthub.io/changes: |
+    - kind: added
+      description: "support for runtimeClassName"
     - kind: changed
       description: "Support kubernetes 1.32"

--- a/charts/clearml-agent/README.md
+++ b/charts/clearml-agent/README.md
@@ -1,6 +1,6 @@
 # ClearML Kubernetes Agent
 
-![Version: 5.3.2](https://img.shields.io/badge/Version-5.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.24](https://img.shields.io/badge/AppVersion-1.24-informational?style=flat-square)
+![Version: 5.3.3](https://img.shields.io/badge/Version-5.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.24](https://img.shields.io/badge/AppVersion-1.24-informational?style=flat-square)
 
 MLOps platform Task running agent
 
@@ -61,13 +61,13 @@ Kubernetes: `>= 1.21.0-0 < 1.33.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| agentk8sglue | object | `{"additionalClusterRoleBindings":[],"additionalRoleBindings":[],"affinity":{},"annotations":{},"apiServerUrlReference":"https://api.clear.ml","basePodTemplate":{"affinity":{},"annotations":{},"containerSecurityContext":{},"env":[],"fileMounts":[],"hostAliases":[],"initContainers":[],"labels":{},"nodeSelector":{},"podSecurityContext":{},"priorityClassName":"","resources":{},"schedulerName":"","tolerations":[],"volumeMounts":[],"volumes":[]},"clearmlcheckCertificate":true,"containerSecurityContext":{},"createQueueIfNotExists":false,"defaultContainerImage":"ubuntu:18.04","extraEnvs":[],"fileMounts":[],"fileServerUrlReference":"https://files.clear.ml","image":{"registry":"","repository":"allegroai/clearml-agent-k8s-base","tag":"1.24-21"},"initContainers":{"resources":{}},"labels":{},"nodeSelector":{},"podSecurityContext":{},"queue":"default","replicaCount":1,"resources":{},"serviceAccountAnnotations":{},"serviceExistingAccountName":"","tolerations":[],"volumeMounts":[],"volumes":[],"webServerUrlReference":"https://app.clear.ml"}` | This agent will spawn queued experiments in new pods, a good use case is to combine this with GPU autoscaling nodes. https://github.com/clearml/clearml-agent/tree/master/docker/k8s-glue |
+| agentk8sglue | object | `{"additionalClusterRoleBindings":[],"additionalRoleBindings":[],"affinity":{},"annotations":{},"apiServerUrlReference":"https://api.clear.ml","basePodTemplate":{"affinity":{},"annotations":{},"containerSecurityContext":{},"env":[],"fileMounts":[],"hostAliases":[],"initContainers":[],"labels":{},"nodeSelector":{},"podSecurityContext":{},"priorityClassName":"","resources":{},"runtimeClassName":"","schedulerName":"","tolerations":[],"volumeMounts":[],"volumes":[]},"clearmlcheckCertificate":true,"containerSecurityContext":{},"createQueueIfNotExists":false,"defaultContainerImage":"ubuntu:18.04","extraEnvs":[],"fileMounts":[],"fileServerUrlReference":"https://files.clear.ml","image":{"registry":"","repository":"allegroai/clearml-agent-k8s-base","tag":"1.24-21"},"initContainers":{"resources":{}},"labels":{},"nodeSelector":{},"podSecurityContext":{},"queue":"default","replicaCount":1,"resources":{},"serviceAccountAnnotations":{},"serviceExistingAccountName":"","tolerations":[],"volumeMounts":[],"volumes":[],"webServerUrlReference":"https://app.clear.ml"}` | This agent will spawn queued experiments in new pods, a good use case is to combine this with GPU autoscaling nodes. https://github.com/clearml/clearml-agent/tree/master/docker/k8s-glue |
 | agentk8sglue.additionalClusterRoleBindings | list | `[]` | additional existing ClusterRoleBindings |
 | agentk8sglue.additionalRoleBindings | list | `[]` | additional existing RoleBindings |
 | agentk8sglue.affinity | object | `{}` | affinity setup for Agent pod (example in values.yaml comments) |
 | agentk8sglue.annotations | object | `{}` | annotations setup for Agent pod (example in values.yaml comments) |
 | agentk8sglue.apiServerUrlReference | string | `"https://api.clear.ml"` | Reference to Api server url |
-| agentk8sglue.basePodTemplate | object | `{"affinity":{},"annotations":{},"containerSecurityContext":{},"env":[],"fileMounts":[],"hostAliases":[],"initContainers":[],"labels":{},"nodeSelector":{},"podSecurityContext":{},"priorityClassName":"","resources":{},"schedulerName":"","tolerations":[],"volumeMounts":[],"volumes":[]}` | base template for pods spawned to consume ClearML Task |
+| agentk8sglue.basePodTemplate | object | `{"affinity":{},"annotations":{},"containerSecurityContext":{},"env":[],"fileMounts":[],"hostAliases":[],"initContainers":[],"labels":{},"nodeSelector":{},"podSecurityContext":{},"priorityClassName":"","resources":{},"runtimeClassName":"","schedulerName":"","tolerations":[],"volumeMounts":[],"volumes":[]}` | base template for pods spawned to consume ClearML Task |
 | agentk8sglue.basePodTemplate.affinity | object | `{}` | affinity setup for pods spawned to consume ClearML Task |
 | agentk8sglue.basePodTemplate.annotations | object | `{}` | annotations setup for pods spawned to consume ClearML Task (example in values.yaml comments) |
 | agentk8sglue.basePodTemplate.containerSecurityContext | object | `{}` | securityContext setup for containers spawned to consume ClearML Task (example in values.yaml comments) |
@@ -80,6 +80,7 @@ Kubernetes: `>= 1.21.0-0 < 1.33.0-0`
 | agentk8sglue.basePodTemplate.podSecurityContext | object | `{}` | securityContext setup for pods spawned to consume ClearML Task (example in values.yaml comments) |
 | agentk8sglue.basePodTemplate.priorityClassName | string | `""` | priorityClassName setup for pods spawned to consume ClearML Task |
 | agentk8sglue.basePodTemplate.resources | object | `{}` | resources declaration for pods spawned to consume ClearML Task (example in values.yaml comments) |
+| agentk8sglue.basePodTemplate.runtimeClassName | string | `""` | kubernetes runtime class name (eg nvidia for use with nvidia gpu operator) |
 | agentk8sglue.basePodTemplate.schedulerName | string | `""` | schedulerName setup for pods spawned to consume ClearML Task |
 | agentk8sglue.basePodTemplate.tolerations | list | `[]` | tolerations setup for pods spawned to consume ClearML Task (example in values.yaml comments) |
 | agentk8sglue.basePodTemplate.volumeMounts | list | `[]` | volume mounts definition for pods spawned to consume ClearML Task (example in values.yaml comments) |

--- a/charts/clearml-agent/templates/agentk8sglue-configmap.yaml
+++ b/charts/clearml-agent/templates/agentk8sglue-configmap.yaml
@@ -30,6 +30,9 @@ data:
       priorityClassName: {{ .Values.agentk8sglue.basePodTemplate.priorityClassName }}
       initContainers:
         {{- toYaml .Values.agentk8sglue.basePodTemplate.initContainers | nindent 8 }}
+      {{- if .values.agentk8sglue.basePodTemplate.runtimeClassName }}
+      runtimeClassName: {{ .values.agentk8sglue.basePodTemplate.runtimeClassName }}
+      {{- end }}
       containers:
       - resources:
           {{- toYaml .Values.agentk8sglue.basePodTemplate.resources | nindent 10 }}

--- a/charts/clearml-agent/templates/agentk8sglue-configmap.yaml
+++ b/charts/clearml-agent/templates/agentk8sglue-configmap.yaml
@@ -30,8 +30,8 @@ data:
       priorityClassName: {{ .Values.agentk8sglue.basePodTemplate.priorityClassName }}
       initContainers:
         {{- toYaml .Values.agentk8sglue.basePodTemplate.initContainers | nindent 8 }}
-      {{- if .values.agentk8sglue.basePodTemplate.runtimeClassName }}
-      runtimeClassName: {{ .values.agentk8sglue.basePodTemplate.runtimeClassName }}
+      {{- if .values.basePodTemplate.runtimeClassName }}
+      runtimeClassName: {{ .values.basePodTemplate.runtimeClassName }}
       {{- end }}
       containers:
       - resources:

--- a/charts/clearml-agent/templates/agentk8sglue-configmap.yaml
+++ b/charts/clearml-agent/templates/agentk8sglue-configmap.yaml
@@ -30,7 +30,7 @@ data:
       priorityClassName: {{ .Values.agentk8sglue.basePodTemplate.priorityClassName }}
       initContainers:
         {{- toYaml .Values.agentk8sglue.basePodTemplate.initContainers | nindent 8 }}
-      runtimeClassName: {{ .values.agentk8sglue.basePodTemplate.runtimeClassName }}
+      runtimeClassName: {{ .Values.agentk8sglue.basePodTemplate.runtimeClassName }}
       containers:
       - resources:
           {{- toYaml .Values.agentk8sglue.basePodTemplate.resources | nindent 10 }}

--- a/charts/clearml-agent/templates/agentk8sglue-configmap.yaml
+++ b/charts/clearml-agent/templates/agentk8sglue-configmap.yaml
@@ -30,9 +30,7 @@ data:
       priorityClassName: {{ .Values.agentk8sglue.basePodTemplate.priorityClassName }}
       initContainers:
         {{- toYaml .Values.agentk8sglue.basePodTemplate.initContainers | nindent 8 }}
-      {{- if .values.basePodTemplate.runtimeClassName }}
-      runtimeClassName: {{ .values.basePodTemplate.runtimeClassName }}
-      {{- end }}
+      runtimeClassName: {{ .values.agentk8sglue.basePodTemplate.runtimeClassName }}
       containers:
       - resources:
           {{- toYaml .Values.agentk8sglue.basePodTemplate.resources | nindent 10 }}

--- a/charts/clearml-agent/values.yaml
+++ b/charts/clearml-agent/values.yaml
@@ -57,6 +57,9 @@ agentk8sglue:
   # -- Glue Agent number of pods
   replicaCount: 1
 
+  # -- kubernetes runtime class name
+  runtimeClassName: ""
+
   # -- Glue Agent pod resources
   resources: {}
 

--- a/charts/clearml-agent/values.yaml
+++ b/charts/clearml-agent/values.yaml
@@ -160,7 +160,7 @@ agentk8sglue:
       #    - >
       #      /bin/echo "this is an init";
 
-    # -- kubernetes runtime class name
+    # -- kubernetes runtime class name (eg nvidia for use with nvidia gpu operator)
     runtimeClassName: ""
 
     # -- schedulerName setup for pods spawned to consume ClearML Task

--- a/charts/clearml-agent/values.yaml
+++ b/charts/clearml-agent/values.yaml
@@ -57,9 +57,6 @@ agentk8sglue:
   # -- Glue Agent number of pods
   replicaCount: 1
 
-  # -- kubernetes runtime class name
-  runtimeClassName: ""
-
   # -- Glue Agent pod resources
   resources: {}
 
@@ -162,6 +159,10 @@ agentk8sglue:
       #    - -c
       #    - >
       #      /bin/echo "this is an init";
+
+    # -- kubernetes runtime class name
+    runtimeClassName: ""
+
     # -- schedulerName setup for pods spawned to consume ClearML Task
     schedulerName: ""
     # -- volumes definition for pods spawned to consume ClearML Task (example in values.yaml comments)


### PR DESCRIPTION
**What this PR does / why we need it**:

When using nvidia gpu-operator, the runtimeClassName needs to be set to nvidia for nvidia to be available


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/clearml/clearml-helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**)
- [x] Verify the work you plan to merge addresses an existing [issue](https://github.com/clearml/clearml-helm-charts/issues) (If not, open a new one) (**required**)
- [x] Check your branch with `helm lint` (**required**)
- [x] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**)
- [x] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifecthub changelog) (**required**)
- [x] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**)


**Which issue(s) this PR fixes**:

Fixes #356 

**Special notes for your reviewer**:

