### PR TITLE
Add default secret generation for clearml-conf and clarify in values.yaml

### DIFF
--- a/charts/clearml/Chart.yaml
+++ b/charts/clearml/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml
 description: MLOps platform
 type: application
-version: "7.14.4"
+version: "7.14.5"
 appVersion: "2.0"
 kubeVersion: ">= 1.21.0-0 < 1.33.0-0"
 home: https://clear.ml
@@ -32,5 +32,5 @@ dependencies:
     condition: elasticsearch.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "casted port to string before concatenation"
+    - kind: added
+      description: "Generate default random secrets for clearml-conf if values are not provided"

--- a/charts/clearml/README.md
+++ b/charts/clearml/README.md
@@ -1,6 +1,6 @@
 # ClearML Ecosystem for Kubernetes
 
-![Version: 7.14.4](https://img.shields.io/badge/Version-7.14.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0](https://img.shields.io/badge/AppVersion-2.0-informational?style=flat-square)
+![Version: 7.14.5](https://img.shields.io/badge/Version-7.14.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0](https://img.shields.io/badge/AppVersion-2.0-informational?style=flat-square)
 
 MLOps platform
 

--- a/charts/clearml/templates/clearml-secrets.yaml
+++ b/charts/clearml/templates/clearml-secrets.yaml
@@ -3,13 +3,13 @@ kind: Secret
 metadata:
   name: clearml-conf
 data:
-  apiserver_key: {{ .Values.clearml.apiserverKey | b64enc }}
-  apiserver_secret: {{ .Values.clearml.apiserverSecret | b64enc }}
-  fileserver_key: {{ .Values.clearml.fileserverKey | b64enc }}
-  fileserver_secret: {{ .Values.clearml.fileserverSecret | b64enc }}
-  secure_auth_token_secret: {{ .Values.clearml.secureAuthTokenSecret | b64enc }}
-  test_user_key: {{ .Values.clearml.testUserKey | b64enc }}
-  test_user_secret: {{ .Values.clearml.testUserSecret | b64enc }}
+  apiserver_key: {{ if .Values.clearml.apiserverKey }}{{ .Values.clearml.apiserverKey | b64enc | quote }}{{ else }}{{ randAlpha 20 | upper | b64enc | quote }}{{ end }}
+  apiserver_secret: {{ if .Values.clearml.apiserverSecret }}{{ .Values.clearml.apiserverSecret | b64enc | quote }}{{ else }}{{ randAlpha 49 | upper | b64enc | quote }}{{ end }}
+  fileserver_key: {{ if .Values.clearml.fileserverKey }}{{ .Values.clearml.fileserverKey | b64enc | quote }}{{ else }}{{ randAlpha 20 | upper | b64enc | quote }}{{ end }}
+  fileserver_secret: {{ if .Values.clearml.fileserverSecret }}{{ .Values.clearml.fileserverSecret | b64enc | quote }}{{ else }}{{ randAlpha 49 | upper | b64enc | quote }}{{ end }}
+  secure_auth_token_secret: {{ if .Values.clearml.secureAuthTokenSecret }}{{ .Values.clearml.secureAuthTokenSecret | b64enc | quote }}{{ else }}{{ randAlpha 50 | b64enc | quote }}{{ end }}
+  test_user_key: {{ if .Values.clearml.testUserKey }}{{ .Values.clearml.testUserKey | b64enc | quote }}{{ else }}{{ randAlpha 20 | upper | b64enc | quote }}{{ end }}
+  test_user_secret: {{ if .Values.clearml.testUserSecret }}{{ .Values.clearml.testUserSecret | b64enc | quote }}{{ else }}{{ randAlpha 50 | upper | b64enc | quote }}{{ end }}
 ---
 {{- if .Values.imageCredentials.enabled }}
 {{- if not .Values.imageCredentials.existingSecret }}

--- a/charts/clearml/values.yaml
+++ b/charts/clearml/values.yaml
@@ -26,24 +26,24 @@ clearml:
   cookieDomain: ""
   # -- Company name
   defaultCompany: "d1bd92a3b039400cbafc60a7a5b1e52b"
-  # -- Api Server basic auth key
-  apiserverKey: GGS9F4M6XB2DXJ5AFT9F
-  # -- Api Server basic auth secret
-  apiserverSecret: 2oGujVFhPfaozhpuz2GzQfA5OyxmMsR3WVJpsCR5hrgHFs20PO
-  # -- File Server basic auth key
-  fileserverKey: XXCRJ123CEE2KSQ068WO
-  # -- File Server basic auth secret
-  fileserverSecret: YIy8EVAC7QCT4FtgitxAQGyW7xRHDZ4jpYlTE7HKiscpORl1hG
+  # -- Api Server basic auth key (will be randomly generated if empty)
+  apiserverKey: ""
+  # -- Api Server basic auth secret (will be randomly generated if empty)
+  apiserverSecret: ""
+  # -- File Server basic auth key (will be randomly generated if empty)
+  fileserverKey: ""
+  # -- File Server basic auth secret (will be randomly generated if empty)
+  fileserverSecret: ""
   # -- Readiness probe basic auth key
   readinessprobeKey: GK4PRTVT3706T25K6BA1
   # -- Readiness probe basic auth secret
   readinessprobeSecret: ymLh1ok5k5xNUQfS944Xdx9xjf0wueokqKM2dMZfHuH9ayItG2
-  # -- Secure Auth secret
-  secureAuthTokenSecret: ymLh1ok5k5xNUQfS944Xdx9xjf0wueokqKM2dMZfHuH9ayItG2
-  # -- Test Server basic auth key
-  testUserKey: "ENP39EQM4SLACGD5FXB7"
-  # -- Test File Server basic auth secret
-  testUserSecret: "lPcm0imbcBZ8mwgO7tpadutiS3gnJD05x9j7afwXPS35IKbpiQ"
+  # -- Secure Auth secret (will be randomly generated if empty)
+  secureAuthTokenSecret: ""
+  # -- Test Server basic auth key (will be randomly generated if empty)
+  testUserKey: ""
+  # -- Test File Server basic auth secret (will be randomly generated if empty)
+  testUserSecret: ""
   # -- Override the API Urls displayed when showing an example of the SDK's clearml.conf configuration
   clientConfigurationApiUrl: ""
   # -- Override the Files Urls displayed when showing an example of the SDK's clearml.conf configuration


### PR DESCRIPTION
**What this PR does / why we need it**:

Add ability to automatically generate random values for clearml-conf secrets if not provided by the user. This makes the chart more user-friendly and secure. - because many of us are working with ArgoCD for deployment and therefor keeping the source code of the k8s in git repo.

Additionally, comments were added in values.yaml to indicate that each secret will be randomly generated if left empty.



**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/clearml/clearml-helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**) done
- [x] Verify the work you plan to merge addresses an existing [issue](https://github.com/clearml/clearml-helm-charts/issues) (If not, open a new one) (**required**) done
- [x] Check your branch with `helm lint` (**required**) done
- [x] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**) done
- [x] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifecthub changelog) (**required**) done
- [x] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**) done


**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Special notes for your reviewer**:

