### PR TITLE
Added: extraEnvs to apiserver-asyncdelete deployment

### DIFF
--- a/charts/clearml/Chart.yaml
+++ b/charts/clearml/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml
 description: MLOps platform
 type: application
-version: "7.14.5"
+version: "7.14.6"
 appVersion: "2.0"
 kubeVersion: ">= 1.21.0-0"
 home: https://clear.ml
@@ -32,5 +32,5 @@ dependencies:
     condition: elasticsearch.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Dropped kubernetes max compatible version"
+    - kind: added
+      description: "extraEnvs to apiserver-asyncdelete deployment"

--- a/charts/clearml/README.md
+++ b/charts/clearml/README.md
@@ -1,6 +1,6 @@
 # ClearML Ecosystem for Kubernetes
 
-![Version: 7.14.5](https://img.shields.io/badge/Version-7.14.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0](https://img.shields.io/badge/AppVersion-2.0-informational?style=flat-square)
+![Version: 7.14.6](https://img.shields.io/badge/Version-7.14.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0](https://img.shields.io/badge/AppVersion-2.0-informational?style=flat-square)
 
 MLOps platform
 
@@ -153,11 +153,13 @@ Kubernetes: `>= 1.21.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| apiserver | object | `{"additionalConfigs":{},"additionalVolumeMounts":{},"additionalVolumes":{},"affinity":{},"containerSecurityContext":{},"deploymentAnnotations":null,"enabled":true,"existingAdditionalConfigsConfigMap":"","existingAdditionalConfigsSecret":"","extraEnvs":[],"image":{"pullPolicy":"IfNotPresent","registry":"","repository":"allegroai/clearml","tag":"2.0.0-613"},"ingress":{"annotations":{},"enabled":false,"hostName":"api.clearml.127-0-0-1.nip.io","ingressClassName":"","path":"/","tlsSecretName":""},"initContainers":{"resources":{"limits":{"cpu":"10m","memory":"64Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}},"nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"prepopulateEnabled":true,"processes":{"count":8,"maxRequests":1000,"maxRequestsJitter":300,"timeout":24000},"replicaCount":1,"resources":{"limits":{"cpu":"2000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"256Mi"}},"service":{"annotations":{},"nodePort":30008,"port":8008,"type":"NodePort"},"serviceAccountAnnotations":{},"serviceAccountName":"clearml","tolerations":[]}` | Api Server configurations |
+| apiserver | object | `{"additionalConfigs":{},"additionalVolumeMounts":{},"additionalVolumes":{},"affinity":{},"asyncdelete":{"extraEnvs":[]},"containerSecurityContext":{},"deploymentAnnotations":null,"enabled":true,"existingAdditionalConfigsConfigMap":"","existingAdditionalConfigsSecret":"","extraEnvs":[],"image":{"pullPolicy":"IfNotPresent","registry":"","repository":"allegroai/clearml","tag":"2.0.0-613"},"ingress":{"annotations":{},"enabled":false,"hostName":"api.clearml.127-0-0-1.nip.io","ingressClassName":"","path":"/","tlsSecretName":""},"initContainers":{"resources":{"limits":{"cpu":"10m","memory":"64Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}},"nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"prepopulateEnabled":true,"processes":{"count":8,"maxRequests":1000,"maxRequestsJitter":300,"timeout":24000},"replicaCount":1,"resources":{"limits":{"cpu":"2000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"256Mi"}},"service":{"annotations":{},"nodePort":30008,"port":8008,"type":"NodePort"},"serviceAccountAnnotations":{},"serviceAccountName":"clearml","tolerations":[]}` | Api Server configurations |
 | apiserver.additionalConfigs | object | `{}` | files declared in this parameter will be mounted and read by apiserver (examples in values.yaml) if not overridden by existingAdditionalConfigsSecret |
 | apiserver.additionalVolumeMounts | object | `{}` | Specifies where and how the volumes defined in additionalVolumes. |
 | apiserver.additionalVolumes | object | `{}` | # Defines extra Kubernetes volumes to be attached to the pod. |
 | apiserver.affinity | object | `{}` | Api Server affinity setup |
+| apiserver.asyncdelete | object | `{"extraEnvs":[]}` | Api Server asyncdelete configurations |
+| apiserver.asyncdelete.extraEnvs | list | `[]` | Api Server asyncdelete extra environment variables |
 | apiserver.containerSecurityContext | object | `{}` | Api Server containers security context |
 | apiserver.deploymentAnnotations | string | `nil` | Add the provided map to the annotations for the Deployment resource created by this chart. |
 | apiserver.enabled | bool | `true` | Enable/Disable component deployment |

--- a/charts/clearml/templates/apiserver-asyncdelete-deployment.yaml
+++ b/charts/clearml/templates/apiserver-asyncdelete-deployment.yaml
@@ -121,6 +121,9 @@ spec:
             value: "{{ .Values.clearml.defaultCompanyGuid }}"
           - name: CLEARML__services__async_urls_delete__fileserver__url_prefixes
             value: "[\"{{ include "clearml.fileUrl" . }}\"]"
+          {{- if .Values.apiserver.asyncdelete.extraEnvs }}
+          {{ toYaml .Values.apiserver.asyncdelete.extraEnvs | nindent 10 }}
+          {{- end }}
           {{- if or .Values.apiserver.additionalConfigs .Values.apiserver.existingAdditionalConfigsConfigMap  .Values.apiserver.existingAdditionalConfigsSecret }}
           volumeMounts:  
             - name: apiserver-config

--- a/charts/clearml/values.yaml
+++ b/charts/clearml/values.yaml
@@ -183,6 +183,10 @@ apiserver:
   additionalVolumeMounts: {}
   #  - mountPath: /dev/shm
   #    name: ramdisk
+  # -- Api Server asyncdelete configurations
+  asyncdelete:
+    # -- Api Server asyncdelete extra environment variables
+    extraEnvs: []
 
 # -- File Server configurations
 fileserver:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `extraEnvs` to `apiserver-asyncdelete` to enable Redis authentication for this deployment.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/clearml/clearml-helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**)
- [x] Verify the work you plan to merge addresses an existing [issue](https://github.com/clearml/clearml-helm-charts/issues) (If not, open a new one) (**required**)
- [x] Check your branch with `helm lint` (**required**)
- [x] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**)
- [x] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifecthub changelog) (**required**)
- [x] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**)


**Which issue(s) this PR fixes**:

Fixes #365 

**Special notes for your reviewer**:
Thank you in advance. If rejected, please provide context or alternative to use Redis authentication for this deployment.
